### PR TITLE
adds UnprocessableError class to allow for correct 422 errors inline …

### DIFF
--- a/lib/status_map.js
+++ b/lib/status_map.js
@@ -3,6 +3,7 @@
 module.exports = function (responses) {
   return new WeakMap([
     [ Error, 500 ],
+    [ responses.UnprocessableError, 422 ],
     [ responses.UnsupportedError, 415 ],
     [ responses.ConflictError, 409 ],
     [ responses.NotAcceptableError, 406 ],


### PR DESCRIPTION
…with JsonApi Spec as used by Ember Js. [Documentation](https://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)